### PR TITLE
fix: get_adjacent_post() with $in_same_term broken

### DIFF
--- a/simple-custom-post-order.php
+++ b/simple-custom-post-order.php
@@ -300,7 +300,7 @@ class SCPO_Engine {
 
         if (isset($post->post_type) && in_array($post->post_type, $objects)) {
             $current_menu_order = $post->menu_order;
-            $where = "WHERE p.menu_order > '" . $current_menu_order . "' AND p.post_type = '" . $post->post_type . "' AND p.post_status = 'publish'";
+            $where = preg_replace("/p.post_date < \'[0-9\-\s\:]+\'/i", "p.menu_order > '" . $current_menu_order . "'", $where);
         }
         return $where;
     }
@@ -327,7 +327,7 @@ class SCPO_Engine {
 
         if (isset($post->post_type) && in_array($post->post_type, $objects)) {
             $current_menu_order = $post->menu_order;
-            $where = "WHERE p.menu_order < '" . $current_menu_order . "' AND p.post_type = '" . $post->post_type . "' AND p.post_status = 'publish'";
+            $where = preg_replace("/p.post_date > \'[0-9\-\s\:]+\'/i", "p.menu_order < '" . $current_menu_order . "'", $where);
         }
         return $where;
     }


### PR DESCRIPTION
Fixes an issue with `get_adjacent_post()` with `$in_same_term` set to `true` not working correctly with SCPOrder. In original code, `$where` statement passed to filter is overridden which is not a good idea as the original query might include more than `post_type` and `post_status` filtering. Our approach is to replace `p.post_date` statement with `p.menu_order` statement while keeping the rest of original statement.