### PR TITLE
Don't change the `orderby` and `order` parameters when they are already set

### DIFF
--- a/simple-custom-post-order.php
+++ b/simple-custom-post-order.php
@@ -470,8 +470,10 @@ class SCPO_Engine {
 
             if (isset($wp_query->query['post_type']) && !isset($_GET['orderby'])) {
                 if (in_array($wp_query->query['post_type'], $objects)) {
-                    $wp_query->set('orderby', 'menu_order');
-                    $wp_query->set('order', 'ASC');
+                    if (!$wp_query->get('orderby'))
+                        $wp_query->set('orderby', 'menu_order');
+                    if (!$wp_query->get('order'))
+                        $wp_query->set('order', 'ASC');
                 }
             }
         } else {


### PR DESCRIPTION
Fix #40

When working in the admin panel, the plugin overrides the parameters `orderby` and `order`. This is done by the `scporder_pre_get_posts()` method of the `SCPO_Engine` class, which is called by the `pre_get_posts` hook.

Look [simple-custom-post-order.php, lines 469-477](https://github.com/ColorlibHQ/simple-custom-post-order/blob/master/simple-custom-post-order.php#L469-L477):
```php
if (is_admin()) {
	if (isset($wp_query->query['post_type']) && !isset($_GET['orderby'])) {
		if (in_array($wp_query->query['post_type'], $objects)) {
			$wp_query->set('orderby', 'menu_order');
			$wp_query->set('order', 'ASC');
		}
	}
} else {
```

I suggest adding here two checks as in the lines going a little lower in the same function.

Look [simple-custom-post-order.php, lines 502-505](https://github.com/ColorlibHQ/simple-custom-post-order/blob/master/simple-custom-post-order.php#L502-L505):
```php
if (!$wp_query->get('orderby'))
	$wp_query->set('orderby', 'menu_order');
if (!$wp_query->get('order'))
	$wp_query->set('order', 'ASC');
```

In my opinion, this preserves the functionality of the plugin and at the same time does not interfere with setting the `orderby` and `order` parameters, when necessary.