### PR TITLE
Allow terms to match the order in the `include` parameter

### DIFF
--- a/simple-custom-post-order.php
+++ b/simple-custom-post-order.php
@@ -64,9 +64,9 @@ class SCPO_Engine {
         add_filter('get_next_post_sort', array($this, 'scporder_next_post_sort'));
 
         add_filter('get_terms_orderby', array($this, 'scporder_get_terms_orderby'), 10, 3);
-        add_filter('wp_get_object_terms', array($this, 'scporder_get_object_terms'), 10, 3);
-        add_filter('get_terms', array($this, 'scporder_get_object_terms'), 10, 3);
-        
+        add_filter('wp_get_object_terms', array($this, 'scporder_get_object_terms'), 10, 4);
+        add_filter('get_terms', array($this, 'scporder_get_terms'), 10, 3);
+
         add_action( 'admin_notices', array( $this, 'scporder_notice_not_checked' ) );
         add_action( 'wp_ajax_scporder_dismiss_notices', array( $this, 'dismiss_notices' ) );
 
@@ -237,7 +237,6 @@ class SCPO_Engine {
         $tags = $this->get_scporder_options_tags();
 
         if (!empty($objects)) {
-            
             foreach ($objects as $object) {
                 $result = $wpdb->get_results("
                     SELECT count(*) as cnt, max(menu_order) as max, min(menu_order) as min
@@ -535,6 +534,9 @@ class SCPO_Engine {
         if (is_admin())
             return $orderby;
 
+        if (isset($args['include']) && isset($args['orderby']) && 'include' === $args['orderby'])
+            return $orderby;
+
         $tags = $this->get_scporder_options_tags();
 
         if (!isset($args['taxonomy']))
@@ -558,10 +560,17 @@ class SCPO_Engine {
         return $orderby;
     }
 
-    public function scporder_get_object_terms($terms) {
+    public function scporder_get_object_terms($terms, $object_ids, $taxonomies, $args) {
+		$this->scporder_get_terms($terms, $taxonomies, $args);
+    }
+
+    public function scporder_get_terms($terms, $taxonomies, $args) {
         $tags = $this->get_scporder_options_tags();
 
         if (is_admin() && isset($_GET['orderby']))
+            return $terms;
+
+        if (isset($args['include']) && isset($args['orderby']) && 'include' === $args['orderby'])
             return $terms;
 
         foreach ($terms as $key => $term) {

--- a/simple-custom-post-order.php
+++ b/simple-custom-post-order.php
@@ -561,7 +561,7 @@ class SCPO_Engine {
     }
 
     public function scporder_get_object_terms($terms, $object_ids, $taxonomies, $args) {
-		$this->scporder_get_terms($terms, $taxonomies, $args);
+        return $this->scporder_get_terms($terms, $taxonomies, $args);
     }
 
     public function scporder_get_terms($terms, $taxonomies, $args) {


### PR DESCRIPTION
Fix #66

To fix the problem it's necessary to change the behavior of the plugin in two aspects.


### 1) scporder_get_terms_orderby()

This method is used with the filter `get_terms_orderby` and changes the `$orderby` on `t.term_order`.
```php
$orderby = 't.term_order';
return $orderby;
```
To fix this, it's enough to add one more check:
```php
if (isset($args['include']) && isset($args['orderby']) && 'include' === $args['orderby'])
	return $orderby;
```


### 2) scporder_get_object_terms()

This method is used with two filters [`get_terms`](https://developer.wordpress.org/reference/hooks/get_terms/) and [`wp_get_object_terms`](https://developer.wordpress.org/reference/hooks/wp_get_object_terms/) and sorts the found terms by the `term_order`.

```php
usort($terms, array($this, 'taxcmp'));
return $terms;
```

This situation is more complicated. To check the `include` option in an array of arguments, we need to pass the `$args` parameter to the function. 
```php
if (isset($args['include']) && isset($args['orderby']) && 'include' === $args['orderby'])
	return $terms;
```

But this parameter is located at different positions in the mentioned hooks:
```php
apply_filters( 'get_terms', $terms, $taxonomies, $args, $term_query );
apply_filters( 'wp_get_object_terms', $terms, $object_ids, $taxonomies, $args );
```

In this regard, I propose to add an auxiliary method. Its role is to invoke a neighboring method with another set of arguments:
```php
public function scporder_get_object_terms($terms, $object_ids, $taxonomies, $args) {
    return $this->scporder_get_terms($terms, $taxonomies, $args);
}

public function scporder_get_terms($terms, $taxonomies, $args) {
```

And use a specific function for each hook:
```php
add_filter('wp_get_object_terms', array($this, 'scporder_get_object_terms'), 10, 4);
add_filter('get_terms', array($this, 'scporder_get_terms'), 10, 3);
```