### PR TITLE
Solve the "Trying to get property ‘cnt’ of non-object" error

### DIFF
--- a/simple-custom-post-order.php
+++ b/simple-custom-post-order.php
@@ -281,8 +281,10 @@ class SCPO_Engine {
                     INNER JOIN $wpdb->term_taxonomy AS term_taxonomy ON ( terms.term_id = term_taxonomy.term_id )
                     WHERE term_taxonomy.taxonomy = '" . $taxonomy . "'
                 ");
-                if ($result[0]->cnt == 0 || $result[0]->cnt == $result[0]->max)
-                    continue;
+                if (count($result) > 0) {
+                    if ($result[0]->cnt == 0 || $result[0]->cnt == $result[0]->max)
+                        continue;
+                }
 
                 $results = $wpdb->get_results("
                     SELECT terms.term_id


### PR DESCRIPTION
On multi-site admin panels there is an error message:
`Notice: Undefined offset: 0 in /usr/share/nginx/html/eatsmart/wp-content/plugins/simple-custom-post-order/simple-custom-post-order.php on line 304`.
This is due to the face that no check is done on the resulting array from a query from the DB, and therefore when it returns empty and the code tries to access its `cnt` property, that error occurs.
Therefore I added a check before the use of the array.

But maybe you should also check why that query is running, or why it's returning no results.