### PR TITLE
Clear the WP object cache after reordering

### DIFF
--- a/simple-custom-post-order.php
+++ b/simple-custom-post-order.php
@@ -361,6 +361,8 @@ class SCPO_Engine {
 			}
 		}
 
+		wp_cache_flush();
+
 		do_action( 'scp_update_menu_order' );
 	}
 
@@ -403,6 +405,8 @@ class SCPO_Engine {
 				); // Passage en requette préparée
 			}
 		}
+
+		wp_cache_flush();
 
 		do_action( 'scp_update_menu_order_tags' );
 


### PR DESCRIPTION
After reordering posts or terms, I added a `wp_cache_flush()` call to empty the object cache. This is necessary, because without this, the plugin doesn't work on environments which have object caching enabled. See #124