### PR TITLE
Allow custom sort order for empty searches made in admin area

### DIFF
--- a/simple-custom-post-order.php
+++ b/simple-custom-post-order.php
@@ -1448,11 +1448,13 @@ class SCPO_Engine {
 			return;
 		}
 
-		if ( is_search() ) {
+		$is_admin = is_admin() && ! wp_doing_ajax();
+
+		if ( ( $is_admin && '' !== $wp_query->get( 's' ) ) || is_search() ) {
 			return;
 		}
 
-		if ( is_admin() && ! wp_doing_ajax() ) {
+		if ( $is_admin ) {
 			if ( isset( $wp_query->query['post_type'] ) && ! isset( $_GET['orderby'] ) ) {
 				if ( in_array( $wp_query->query['post_type'], $objects, true ) ) {
 					if ( ! $wp_query->get( 'orderby' ) ) {


### PR DESCRIPTION
Hi,

Thanks for the useful plugin. One of our users noticed that when using the "All dates" or "All Categories" dropdown filters on the [Posts admin dashboard page](https://wordpress.org/documentation/article/posts-screen/), the custom sort order would not apply.

The issue is when using the "All dates" or "All Categories" dropdown filter, an empty `'s'` parameter is added to the URL querystring. Even if the `'s'` parameter is empty, the `is_search()` function will still return `true`.

`is_search()` is used by your plugin to determine whether the custom sort order is used or not:

https://github.com/ColorlibHQ/simple-custom-post-order/blob/a4cbfa9ce8f6b3b93478650a8492747564e66700/simple-custom-post-order.php#L1451-L1453

So for this PR, I've made a small adjustment to the `is_search()` line to see if the `s` parameter is empty or not. If it is empty, allow the custom sort to proceed. I've made it so this is only applied in the admin area to allow frontend searches to work as they have before, but feel free to make changes how you see fit.